### PR TITLE
Fix default value of ReminderOptions

### DIFF
--- a/cli/src/subcommand/run.rs
+++ b/cli/src/subcommand/run.rs
@@ -4,10 +4,10 @@ use reminder_lint_core::ReminderOptions;
 use crate::args::RunCommand;
 
 pub fn execute_run(command: RunCommand) -> Result<(), Error> {
-    let options = ReminderOptions {
-        config_file_path: command.config_file_path.as_deref(),
-        ignore_file_path: command.ignore_file_path.as_deref(),
-    };
+    let options = ReminderOptions::builder()
+        .config_file_path(command.config_file_path.as_deref())
+        .ignore_file_path(command.ignore_file_path.as_deref())
+        .build();
 
     let reminders = reminder_lint_core::reminders(&options)?;
     for remind in reminders.expired {

--- a/core/src/options.rs
+++ b/core/src/options.rs
@@ -2,16 +2,73 @@ pub const DEFAULT_CONFIG_FILE_PATH: &str = "remind.yaml";
 pub const DEFAULT_IGNORE_FILE_PATH: &str = ".remindignore";
 
 pub struct ReminderOptions<'a> {
-    pub config_file_path: Option<&'a str>,
-    pub ignore_file_path: Option<&'a str>,
+    config_file_path: Option<&'a str>,
+    ignore_file_path: Option<&'a str>,
 }
 
-impl ReminderOptions<'_> {
+impl<'a> ReminderOptions<'a> {
+    // Public constructor to initialize the options with default values
+    pub fn builder() -> ReminderOptionsBuilder<'a> {
+        ReminderOptionsBuilder {
+            config_file_path: None,
+            ignore_file_path: None,
+        }
+    }
+
+    // Getters for the file paths
     pub fn config_file(&self) -> &str {
         self.config_file_path.unwrap_or(DEFAULT_CONFIG_FILE_PATH)
     }
 
     pub fn ignore_file(&self) -> &str {
         self.ignore_file_path.unwrap_or(DEFAULT_IGNORE_FILE_PATH)
+    }
+}
+
+pub struct ReminderOptionsBuilder<'a> {
+    config_file_path: Option<&'a str>,
+    ignore_file_path: Option<&'a str>,
+}
+
+impl<'a> ReminderOptionsBuilder<'a> {
+    pub fn config_file_path(mut self, config_file_path: Option<&'a str>) -> Self {
+        self.config_file_path = config_file_path;
+        self
+    }
+
+    pub fn ignore_file_path(mut self, ignore_file_path: Option<&'a str>) -> Self {
+        self.ignore_file_path = ignore_file_path;
+        self
+    }
+
+    pub fn build(self) -> ReminderOptions<'a> {
+        ReminderOptions {
+            config_file_path: self.config_file_path,
+            ignore_file_path: self.ignore_file_path,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reminder_options() {
+        let options = ReminderOptions::builder()
+            .config_file_path(Some("config.yaml"))
+            .ignore_file_path(Some("ignore.yaml"))
+            .build();
+
+        assert_eq!(options.config_file(), "config.yaml");
+        assert_eq!(options.ignore_file(), "ignore.yaml");
+    }
+
+    #[test]
+    fn test_default_reminder_options() {
+        let options = ReminderOptions::builder().build();
+
+        assert_eq!(options.config_file(), DEFAULT_CONFIG_FILE_PATH);
+        assert_eq!(options.ignore_file(), DEFAULT_IGNORE_FILE_PATH);
     }
 }


### PR DESCRIPTION
## Overviews
This PR fixes the default value of the CLI option.  df18e2dda086

Additionally, it switches to the builder pattern in the ReminderOptions struct to properly encapsulate its properties. This change ensures proper handling of default values and enhances code safety and clarity. a5a316983439

**Before:**
```rust
let options = ReminderOptions {
    config_file_path: Some("config.yaml"),
    ignore_file_path: Some("ignore.yaml"),
};
```

**After:**
```rust
let options = ReminderOptions::builder()
    .config_file_path(Some("config.yaml"))
    .ignore_file_path(Some("ignore.yaml"))
    .build();
```