### PR TITLE
ci: build and push docker image to ghcr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 permissions:
   contents: write
   pull-requests: write
+  packages: write
 
 on:
   workflow_dispatch:
@@ -31,6 +32,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
@@ -39,6 +42,12 @@ jobs:
 
       - name: Install cargo-release
         run: cargo install cargo-release --locked
+
+      - name: Cargo release version
+        run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+          cargo release version --execute --no-confirm ${{ github.event.inputs.version }}
 
       - id: git-cliff
         name: Generate the changelog
@@ -49,15 +58,12 @@ jobs:
         env:
           OUTPUT: CHANGELOG.md
 
-      - name: Cargo release
+      - name: Cargo release commit
         run: |
-          git config --global user.name "${{ github.actor }}"
-          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
-          cargo release version --execute --no-confirm ${{ github.event.inputs.version }}
           git checkout -b release-${{ github.event.inputs.version }}
           cargo release commit --execute --no-confirm
           git push -u origin HEAD
-          git fetch origin master
+          git fetch origin main
           gh pr create --title "Release ${{ github.event.inputs.version }}" --body "${{ steps.git-cliff.outputs.content }}"
 
           while [[ ! "$(gh pr status --json state | jq '.currentBranch.state')" =~ "OPEN" ]]; do
@@ -66,6 +72,48 @@ jobs:
           done
 
           gh pr merge --squash --delete-branch
+          
+          git tag "${{ github.event.inputs.version }}"
+          git push origin "${{ github.event.inputs.version }}"
+
+  build-and-push:
+    needs:
+      - tag-version
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.version }}
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{major}}
+            type=raw,latest
+            type=raw,value=${{ matrix.target.platform }}
+            type=raw,value=${{ github.event.inputs.version }}
+
+      - id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v4
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          platforms: linux/amd64,linux/arm64
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
   plan:
     needs:
@@ -78,7 +126,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: master
+          ref: ${{ github.event.inputs.version }}
 
       - name: Install cargo-dist
         shell: bash
@@ -115,7 +163,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: master
+          ref: ${{ github.event.inputs.version }}
 
       - uses: swatinem/rust-cache@v2
         with:
@@ -169,7 +217,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: master
+          ref: ${{ github.event.inputs.version }}
 
       - name: Install cargo-dist
         shell: bash
@@ -216,7 +264,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: master
+          ref: ${{ github.event.inputs.version }}
 
       - name: Install cargo-dist
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.16.0/cargo-dist-installer.sh | sh"
@@ -253,7 +301,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: master
+          ref: ${{ github.event.inputs.version }}
 
       - name: Download GitHub Artifacts
         uses: actions/download-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM --platform=$BUILDPLATFORM messense/rust-musl-cross:aarch64-musl-${TARGETARCH} AS builder
+
+ARG TARGETARCH
+
+WORKDIR /build
+
+RUN if [ $TARGETARCH = "amd64" ]; then \
+      echo "x86_64" > /arch; \
+    elif [ $TARGETARCH = "arm64" ]; then \
+      echo "aarch64" > /arch; \
+    else \
+      echo "$TARGETARCH is not supported"; \
+      exit 1; \
+    fi
+
+COPY . .
+
+RUN rustup target add $(cat /arch)-unknown-linux-musl && \
+    cargo build --package reminder-lint --locked --release --target $(cat /arch)-unknown-linux-musl
+
+RUN cp target/$(cat /arch)-unknown-linux-musl/release/reminder-lint /build/reminder-lint
+
+
+FROM --platform=$TARGETPLATFORM debian:bullseye-slim
+
+COPY --from=builder /build/reminder-lint /usr/local/bin/reminder-lint/cli
+
+ENTRYPOINT [ "/usr/local/bin/reminder-lint/cli" ]


### PR DESCRIPTION
resolve https://github.com/CyberAgent/reminder-lint/issues/5

### Push to Container Registry
Added a job to the release workflow to build and push a Docker image (using ghcr.io).
The image platforms are `linux/arm64` and `linux/amd64`, as they are intended for continuous integration use.