### PR TITLE
ci: add custom action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,14 @@
+name: 'reminder-lint'
+description: 'Custom action for reminder-lint cli.'
+
+inputs:
+  args:
+    description: Arguments to pass to the reminder-lint.
+    required: false
+    default: 'run'
+
+runs:
+  using: docker
+  image: docker://ghcr.io/CyberAgent/reminder-lint:latest
+  args:
+    - ${{ inputs.args }}


### PR DESCRIPTION
### Overview
Added GitHub custom action configuration using Docker container.
Users will be able to run reminder-lint on CI using the uses syntax.

cf. https://docs.github.com/actions/creating-actions

Example
```yaml
name: reminder-lint

on:
  schedule:
    - cron: '0 1 * * 1,2,3,4,5'

jobs:
  run:
    runs-on: ubuntu-latest
    name: reminder-lint
    steps:
      - name: Checkout
        uses: actions/checkout@v4

      - name: Run
        uses: CyberAgent/reminder-lint@main
        with:
          args: run
```
