### PR TITLE
config: rename config file and default option

### DIFF
--- a/.remindignore
+++ b/.remindignore
@@ -1,1 +1,0 @@
-testdata/test.txt

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -18,7 +18,7 @@ pub enum Subcommand {
 #[argh(subcommand, name = "run")]
 /// run reminder-lint with a path
 pub struct RunCommand {
-    /// path to the config file (default: ./remind.yaml)
+    /// path to the config file (default: ./remind.yml)
     #[argh(option, short = 'c')]
     pub config_file_path: Option<String>,
     /// path to the ignore file (default: ./.remindignore)

--- a/cli/src/subcommand/init.rs
+++ b/cli/src/subcommand/init.rs
@@ -53,7 +53,7 @@ fn init_prompt() -> Result<InitPromptResult, Error> {
                     "Please select the datetime format",
                     vec![
                         SelectOption::new("%Y/%m/%d", "%Y/%m/%d"),
-                        SelectOption::new("%Y/%m/%d/%/H/%M/%S", "%Y/%m/%d/%/H/%M/%S"),
+                        SelectOption::new("%Y/%m/%d %H:%M:%S", "%Y/%m/%d %H:%M:%S"),
                     ],
                 )
                 .as_mut(),

--- a/core/src/options.rs
+++ b/core/src/options.rs
@@ -1,4 +1,4 @@
-pub const DEFAULT_CONFIG_FILE_PATH: &str = "remind.yaml";
+pub const DEFAULT_CONFIG_FILE_PATH: &str = "remind.yml";
 pub const DEFAULT_IGNORE_FILE_PATH: &str = ".remindignore";
 
 pub struct ReminderOptions<'a> {
@@ -56,12 +56,12 @@ mod tests {
     #[test]
     fn test_reminder_options() {
         let options = ReminderOptions::builder()
-            .config_file_path(Some("config.yaml"))
-            .ignore_file_path(Some("ignore.yaml"))
+            .config_file_path(Some("config.yml"))
+            .ignore_file_path(Some("ignore.yml"))
             .build();
 
-        assert_eq!(options.config_file(), "config.yaml");
-        assert_eq!(options.ignore_file(), "ignore.yaml");
+        assert_eq!(options.config_file(), "config.yml");
+        assert_eq!(options.ignore_file(), "ignore.yml");
     }
 
     #[test]

--- a/remind.yaml
+++ b/remind.yaml
@@ -1,3 +1,0 @@
-comment_regex: 'remind:\W?'
-datetime_format: "%Y/%m/%d"
-search_directory: .

--- a/remind.yml
+++ b/remind.yml
@@ -1,0 +1,3 @@
+comment_regex: remind:\W?
+datetime_format: '%Y/%m/%d %H:%M:%S'
+search_directory: .


### PR DESCRIPTION
# Overview
Renamed the config file extension from .yaml to .yml to align with other YAML files.
Additionally, changed the format of the default value for selectable date.