### PR TITLE
config: add filtering option for comments with no date

### DIFF
--- a/cli/src/subcommand/init.rs
+++ b/cli/src/subcommand/init.rs
@@ -67,10 +67,16 @@ fn init_prompt() -> Result<InitPromptResult, Error> {
                 .with_hint(hint_format(&default_config.search_directory)),
         )?;
 
+        let remind_if_no_date = p.prompt(
+            Confirm::new("Remind if no datetime in comment?")
+                .with_default(default_config.remind_if_no_date),
+        )?;
+
         result.config = Some(Config {
             comment_regex,
             datetime_format,
             search_directory,
+            remind_if_no_date,
         });
     }
 

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -8,6 +8,7 @@ pub struct Config {
     pub comment_regex: String,
     pub datetime_format: String,
     pub search_directory: String,
+    pub remind_if_no_date: bool,
 }
 
 impl Default for Config {
@@ -16,6 +17,7 @@ impl Default for Config {
             comment_regex: String::from(r"remind:\W?"),
             datetime_format: "%Y/%m/%d".to_string(),
             search_directory: ".".to_string(),
+            remind_if_no_date: false,
         }
     }
 }
@@ -26,6 +28,7 @@ pub fn load_config(filename: &str) -> Result<Config, ConfigError> {
         .set_default("comment_regex", default.comment_regex)?
         .set_default("datetime_format", default.datetime_format)?
         .set_default("search_directory", default.search_directory)?
+        .set_default("remind_if_no_date", default.remind_if_no_date)?
         .add_source(config::File::with_name(filename).required(false))
         .add_source(config::Environment::with_prefix(REMIND_ENV_PREFIX))
         .build()?;

--- a/core/src/remind/mod.rs
+++ b/core/src/remind/mod.rs
@@ -60,6 +60,7 @@ pub fn list_reminders(config: &Config, ignore_config_file: &str) -> Result<Vec<R
                     config.datetime_format.to_owned(),
                     &datetime_regex,
                     &config.comment_regex,
+                    config.remind_if_no_date,
                 ),
             );
             Some(reminders)
@@ -71,12 +72,22 @@ pub fn list_reminders(config: &Config, ignore_config_file: &str) -> Result<Vec<R
 }
 
 fn parse_datetime(v: &str, format: &str) -> Result<i64, Error> {
-    if format.contains("%H") || format.contains("%M") || format.contains("%S") {
-        let datetime = NaiveDateTime::parse_from_str(&v, &format)?;
-        Ok(datetime.and_utc().timestamp())
-    } else {
-        let date = NaiveDate::parse_from_str(&v, &format)?;
-        Ok(date.and_time(NaiveTime::default()).and_utc().timestamp())
+    match v {
+        "" => Ok(0),
+        _ => {
+            let parsed_date =
+                if format.contains("%H") || format.contains("%M") || format.contains("%S") {
+                    NaiveDateTime::parse_from_str(v, format)?
+                        .and_utc()
+                        .timestamp()
+                } else {
+                    NaiveDate::parse_from_str(v, format)?
+                        .and_time(NaiveTime::default())
+                        .and_utc()
+                        .timestamp()
+                };
+            Ok(parsed_date)
+        }
     }
 }
 
@@ -86,30 +97,31 @@ fn line_processor<'a>(
     datetime_format: String,
     datetime_regex: &'a Regex,
     comment_regex: &'a str,
+    remind_if_no_date: bool,
 ) -> UTF8<impl FnMut(u64, &str) -> Result<bool, io::Error> + 'a> {
-    UTF8(move |line_num, line| match datetime_regex.find(line) {
-        Some(m) => {
-            let datetime_str = m.as_str();
-            let parsed = parse_datetime(&datetime_str, &datetime_format);
-            let datetime = parsed.unwrap_or_else(|e| {
-                eprintln!("Error parsing datetime: {}", e);
-                0
-            });
-            let meta: HashMap<String, String> =
-                extract_placeholders(comment_regex, line).unwrap_or_else(|| HashMap::new());
-
-            reminds.push(Remind {
-                datetime,
-                message: line.trim_start().to_string(),
-                position: Position {
-                    file: entry_path.clone(),
-                    line: line_num.into(),
-                },
-                meta,
-            });
-            Ok(true)
+    UTF8(move |line_num, line| {
+        let datetime_str = datetime_regex.find(line).map_or("", |m| m.as_str());
+        let parsed = parse_datetime(&datetime_str, &datetime_format);
+        let datetime = parsed.unwrap_or_else(|_| {
+            eprintln!("Failed to parse datetime: {}", datetime_str);
+            0
+        });
+        if datetime == 0 && !remind_if_no_date {
+            return Ok(false);
         }
-        None => Ok(false),
+        let meta: HashMap<String, String> =
+            extract_placeholders(comment_regex, line).unwrap_or_else(|| HashMap::new());
+
+        reminds.push(Remind {
+            datetime,
+            message: line.trim_start().to_string(),
+            position: Position {
+                file: entry_path.clone(),
+                line: line_num.into(),
+            },
+            meta,
+        });
+        Ok(true)
     })
 }
 

--- a/remind.yml
+++ b/remind.yml
@@ -1,3 +1,4 @@
 comment_regex: remind:\W?
-datetime_format: '%Y/%m/%d %H:%M:%S'
+datetime_format: '%Y/%m/%d'
 search_directory: .
+remind_if_no_date: false


### PR DESCRIPTION
Resolve https://github.com/CyberAgent/reminder-lint/issues/19

### Overview
Add the option for filtering blank date(time) comments.
This option is intended to be used during the migration process from general TODO comments to reminder comments.

#### with `remind_if_no_date: false`
```rs
// remind: this comment is not reminded
```

#### with `remind_if_no_date: true`
```rs
// remind: this comment is reminded
```