### PR TITLE
action: fixed to repository name to lowercase

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1,7 +1,7 @@
 # reminder-lint
 `reminder-lint`はあらゆる言語や設定ファイルに対応した、コードリマインドツールです。  
 
-[GitHub Actionsで使用する](https://github.com/CyberAgent/reminder-lint)  
+[GitHub Actionsで使用する](https://github.com/CyberAgent/reminder-lint#GitHub-Actions)  
 [ローカル環境にインストールする](https://github.com/CyberAgent/reminder-lint#Install)
 
 ## コンセプト
@@ -30,7 +30,7 @@ $ reminder-lint run
 
 ### Docker
 ```shell
-$ docker run --rm -v "$(pwd):/workspace" --workdir /workspace ghcr.io/CyberAgent/reminder-lint:latest run
+$ docker run --rm -v "$(pwd):/workspace" --workdir /workspace ghcr.io/cyberagent/reminder-lint:latest run
 ```
 
 ### Binary
@@ -72,7 +72,7 @@ $ reminder-lint init
 
 または、Dockerを利用して設定ファイルを生成することができます。
 ```shell
-$ docker run --rm -it -v "$(pwd):/workspace" --workdir /workspace ghcr.io/CyberAgent/reminder-lint:latest init
+$ docker run --rm -it -v "$(pwd):/workspace" --workdir /workspace ghcr.io/cyberagent/reminder-lint:latest init
 ```
 
 ### Syntaxのカスタマイズ

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ reminder-lint run
 
 ### Docker
 ```shell
-$ docker run --rm -v "$(pwd):/workspace" --workdir /workspace ghcr.io/CyberAgent/reminder-lint:latest run
+$ docker run --rm -v "$(pwd):/workspace" --workdir /workspace ghcr.io/cyberagent/reminder-lint:latest run
 ```
 
 ### Binary
@@ -73,7 +73,7 @@ $ reminder-lint init
 
 Or, you can use Docker to generate configuration files.
 ```shell
-$ docker run --rm -it -v "$(pwd):/workspace" --workdir /workspace ghcr.io/CyberAgent/reminder-lint:latest init
+$ docker run --rm -it -v "$(pwd):/workspace" --workdir /workspace ghcr.io/cyberagent/reminder-lint:latest init
 ```
 
 ### Syntax Customization

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,6 @@ inputs:
 
 runs:
   using: docker
-  image: docker://ghcr.io/CyberAgent/reminder-lint:latest
+  image: docker://ghcr.io/cyberagent/reminder-lint:latest
   args:
     - ${{ inputs.args }}


### PR DESCRIPTION
Fixed repository name error.
```
$ docker run --rm -v "$(pwd):/workspace" --workdir /workspace ghcr.io/CyberAgent/reminder-lint:latest run
docker: invalid reference format: repository name (CyberAgent/reminder-lint) must be lowercase.
```

`ghcr.io/cyberagent/reminder-lint:latest` works well.