### PR TITLE
review: add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @arabian9ts @kqito @dora1998


### PR DESCRIPTION
Added `CODEOWNERS` file.
We could use github team for assigning review, but it's better that all maintainers review the PR, so listed maintainers.

cf. https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners