### PR TITLE
list: add subcommand for listing remind comments

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -12,6 +12,7 @@ pub struct Args {
 pub enum Subcommand {
     Run(RunCommand),
     Init(InitCommand),
+    List(ListCommand),
 }
 
 #[derive(FromArgs, PartialEq, Debug)]
@@ -33,6 +34,18 @@ pub struct RunCommand {
 #[argh(subcommand, name = "init")]
 /// initialize a config of reminder-lint
 pub struct InitCommand {}
+
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "list")]
+/// list reminder-lint comments
+pub struct ListCommand {
+    /// path to the config file (default: ./remind.yml)
+    #[argh(option, short = 'c')]
+    pub config_file_path: Option<String>,
+    /// path to the ignore file (default: ./.remindignore)
+    #[argh(option, short = 'i')]
+    pub ignore_file_path: Option<String>,
+}
 
 impl Args {
     pub fn new() -> Self {

--- a/cli/src/subcommand/list.rs
+++ b/cli/src/subcommand/list.rs
@@ -1,0 +1,28 @@
+use crate::args::ListCommand;
+use anyhow::Error;
+use reminder_lint_core::config::builder::ConfigBuilder;
+
+pub fn execute_list(command: ListCommand) -> Result<(), Error> {
+    let conf = ConfigBuilder::new()
+        .config_file_path(command.config_file_path)
+        .ignore_file_path(command.ignore_file_path)
+        .build()?;
+
+    let reminders = reminder_lint_core::reminders(&conf)?;
+
+    for remind in &reminders.expired {
+        println!(
+            "{}:{} {}",
+            remind.position.file, remind.position.line, remind.message
+        );
+    }
+
+    for remind in &reminders.upcoming {
+        println!(
+            "{}:{} {}",
+            remind.position.file, remind.position.line, remind.message
+        );
+    }
+
+    Ok(())
+}

--- a/cli/src/subcommand/mod.rs
+++ b/cli/src/subcommand/mod.rs
@@ -3,15 +3,17 @@ use crate::{
     print::{pretty_print, Status},
 };
 
-use self::{init::execute_init, run::execute_run};
+use self::{init::execute_init, list::execute_list, run::execute_run};
 
 mod init;
+mod list;
 mod run;
 
 pub fn execute_subcommand(subcommand: Subcommand) {
     let result = match subcommand {
         Subcommand::Run(command) => execute_run(command),
         Subcommand::Init(command) => execute_init(command),
+        Subcommand::List(command) => execute_list(command),
     };
 
     if let Err(e) = result {


### PR DESCRIPTION
### Overview
Added simple list command for listing comments.
This command refers `remind.yml` and `.remindignore` to determine comment regex or ignore files.
Also, now filter options are not implemented.

https://github.com/CyberAgent/reminder-lint/issues/33