### PR TITLE
Add some tests for name extract placeholder as meta

### DIFF
--- a/core/src/remind/meta.rs
+++ b/core/src/remind/meta.rs
@@ -144,4 +144,13 @@ mod tests {
 
         assert_eq!(extract_placeholders(pattern, text), expected);
     }
+
+    #[test]
+    fn test_native_name_extract_partial_placeholders() {
+        let pattern = r"(@(?P<assignee>.+) )?remind: (?P<task>.*)\W?";
+        let text = "remind: TODO";
+        let expected = Some(HashMap::from([("task".to_string(), "TODO".to_string())]));
+
+        assert_eq!(extract_placeholders(pattern, text), expected);
+    }
 }


### PR DESCRIPTION
resolves https://github.com/CyberAgent/reminder-lint/issues/32

- The functionality for #32 has already been added in https://github.com/CyberAgent/reminder-lint/pull/10, so there is no to implement anything new.
- Therefore, this PR only adds tests to verify that issue #32 is working correctly.