### PR TITLE
pass search path from command args

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -28,6 +28,9 @@ pub struct RunCommand {
     /// sort by deadline (default: false)
     #[argh(switch)]
     pub sort_by_deadline: Option<bool>,
+    // search path (default: search directry written in config file)
+    #[argh(positional)]
+    pub search_path: Option<String>,
 }
 
 #[derive(FromArgs, PartialEq, Debug)]
@@ -45,6 +48,9 @@ pub struct ListCommand {
     /// path to the ignore file (default: ./.remindignore)
     #[argh(option, short = 'i')]
     pub ignore_file_path: Option<String>,
+    // search path (default: search directry written in config file)
+    #[argh(positional)]
+    pub search_path: Option<String>,
 }
 
 impl Args {

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -12,6 +12,7 @@ pub struct Args {
 pub enum Subcommand {
     Run(RunCommand),
     Init(InitCommand),
+    List(ListCommand),
 }
 
 #[derive(FromArgs, PartialEq, Debug)]
@@ -33,6 +34,18 @@ pub struct RunCommand {
 #[argh(subcommand, name = "init")]
 /// initialize a config of reminder-lint
 pub struct InitCommand {}
+
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "list")]
+/// list reminder-lint comments
+pub struct ListCommand {
+    /// path to the config file (default: ./remind.yml)
+    #[argh(option, short = 'c')]
+    pub config_file_path: Option<String>,
+    /// path to the ignore file (default: ./.remindignore)
+    #[argh(option, short = 'i')]
+    pub ignore_file_path: Option<String>,
+}
 
 impl Args {
     pub fn new() -> Self {

--- a/cli/src/subcommand/list.rs
+++ b/cli/src/subcommand/list.rs
@@ -1,0 +1,28 @@
+use crate::args::ListCommand;
+use anyhow::Error;
+use reminder_lint_core::config::builder::ConfigBuilder;
+
+pub fn execute_list(command: ListCommand) -> Result<(), Error> {
+    let conf = ConfigBuilder::new()
+        .config_file_path(command.config_file_path)
+        .ignore_file_path(command.ignore_file_path)
+        .build()?;
+
+    let reminders = reminder_lint_core::reminders(&conf)?;
+
+    for remind in &reminders.expired {
+        println!(
+            "{}:{} {}",
+            remind.position.file, remind.position.line, remind.message
+        );
+    }
+
+    for remind in &reminders.upcoming {
+        println!(
+            "{}:{} {}",
+            remind.position.file, remind.position.line, remind.message
+        );
+    }
+
+    Ok(())
+}

--- a/cli/src/subcommand/list.rs
+++ b/cli/src/subcommand/list.rs
@@ -8,7 +8,7 @@ pub fn execute_list(command: ListCommand) -> Result<(), Error> {
         .ignore_file_path(command.ignore_file_path)
         .build()?;
 
-    let reminders = reminder_lint_core::reminders(&conf)?;
+    let reminders = reminder_lint_core::reminders(&conf, command.search_path)?;
 
     for remind in &reminders.expired {
         println!(

--- a/cli/src/subcommand/mod.rs
+++ b/cli/src/subcommand/mod.rs
@@ -3,15 +3,17 @@ use crate::{
     print::{pretty_print, Status},
 };
 
-use self::{init::execute_init, run::execute_run};
+use self::{init::execute_init, list::execute_list, run::execute_run};
 
 mod init;
+mod list;
 mod run;
 
 pub fn execute_subcommand(subcommand: Subcommand) {
     let result = match subcommand {
         Subcommand::Run(command) => execute_run(command),
         Subcommand::Init(command) => execute_init(command),
+        Subcommand::List(command) => execute_list(command),
     };
 
     if let Err(e) = result {

--- a/cli/src/subcommand/run.rs
+++ b/cli/src/subcommand/run.rs
@@ -10,7 +10,8 @@ pub fn execute_run(command: RunCommand) -> Result<(), Error> {
         .sort_by_deadline(command.sort_by_deadline)
         .build()?;
 
-    let reminders = reminder_lint_core::reminders(&conf)?;
+    let reminders = reminder_lint_core::reminders(&conf, command.search_path)?;
+
     for remind in &reminders.expired {
         println!(
             "{}:{} {}",

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,8 +12,11 @@ pub struct Reminders {
     pub upcoming: Vec<remind::Remind>,
 }
 
-pub fn reminders(conf: &Config) -> Result<Reminders, ReminderLintError> {
-    let reminders = list_reminders(&conf).map_err(|e| ReminderLintError::from(e))?;
+pub fn reminders(
+    conf: &Config,
+    search_path: Option<String>,
+) -> Result<Reminders, ReminderLintError> {
+    let reminders = list_reminders(&conf, search_path).map_err(|e| ReminderLintError::from(e))?;
 
     let mut expired = Vec::new();
     let mut upcoming = Vec::new();

--- a/core/src/remind/mod.rs
+++ b/core/src/remind/mod.rs
@@ -27,7 +27,7 @@ pub struct Position {
     pub line: u64,
 }
 
-pub fn list_reminders(config: &Config) -> Result<Vec<Remind>, Error> {
+pub fn list_reminders(config: &Config, target: Option<String>) -> Result<Vec<Remind>, Error> {
     let meta_regex = convert_meta_regex(&config.comment_regex());
     let matcher = RegexMatcherBuilder::new().build(&meta_regex)?;
 
@@ -37,7 +37,10 @@ pub fn list_reminders(config: &Config) -> Result<Vec<Remind>, Error> {
         .line_number(true)
         .build();
 
-    let mut builder = WalkBuilder::new(&config.search_directory());
+    let mut builder = match target {
+        Some(t) => WalkBuilder::new(&t),
+        None => WalkBuilder::new(config.search_directory()),
+    };
     let walker = builder
         .hidden(false)
         .add_custom_ignore_filename(&config.ignore_file_path())


### PR DESCRIPTION
A feature that allows you to pass the search path from command arguments has been added.
When searching frequently, such as when using an editor extension, we should search only the target files.

## Example

```
$ reminder-lint list         <-- search the directory written in config file
$ reminder-lint list ./foo   <-- search `./foo` (file and dir are OK)
```