### PR TITLE
feat: add problem matchers

### DIFF
--- a/.github/matcher.json
+++ b/.github/matcher.json
@@ -1,0 +1,15 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "reminder-lint",
+      "pattern": [
+        {
+          "regexp": "^(.+):(\\d+)\\s(.+)$",
+          "file": 1,
+          "line": 2,
+          "message": 3
+        }
+      ]
+    }
+  ]
+}

--- a/action.yml
+++ b/action.yml
@@ -1,14 +1,14 @@
-name: 'reminder-lint'
-description: 'Custom action for reminder-lint cli.'
+name: "reminder-lint"
+description: "Custom action for reminder-lint cli."
 
 inputs:
   args:
     description: Arguments to pass to the reminder-lint.
     required: false
-    default: 'run'
+    default: "run"
 
 runs:
   using: docker
-  image: docker://ghcr.io/cyberagent/reminder-lint:latest
+  image: ./actions/Dockerfile
   args:
     - ${{ inputs.args }}

--- a/actions/Dockerfile
+++ b/actions/Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/cyberagent/reminder-lint:latest
+
+COPY entrypoint.sh /usr/local/bin/reminder-lint/
+
+ENTRYPOINT [ "/usr/local/bin/reminder-lint/entrypoint.sh" ]

--- a/actions/entrypoint.sh
+++ b/actions/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -l
+if [ "$1" = "run" ]; then
+  echo "::add-matcher::.github/matcher.json"
+fi
+
+/usr/local/bin/reminder-lint/cli "$@"
+
+if [ "$1" = "run" ]; then
+  echo "::remove-matcher owner=reminder-lint::"
+fi


### PR DESCRIPTION
Adds problem matchers in custom actions.
It only works with `run` command because we cannot tell `expired` from `upcoming` in `list` command.

## Screenshots

![image](https://github.com/user-attachments/assets/e1311c49-fee9-4f52-be4d-413370213044)

https://github.com/CyberAgent/reminder-lint/actions/runs/11304190247?pr=40

## References

- https://github.com/actions/toolkit/blob/main/docs/commands.md#problem-matchers
- https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md