### PR TITLE
feat: add `--json` option to list command

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -45,6 +45,9 @@ pub struct ListCommand {
     /// path to the ignore file (default: ./.remindignore)
     #[argh(option, short = 'i')]
     pub ignore_file_path: Option<String>,
+    /// output in json format
+    #[argh(switch)]
+    pub json: bool,
 }
 
 impl Args {

--- a/cli/src/subcommand/list.rs
+++ b/cli/src/subcommand/list.rs
@@ -10,6 +10,11 @@ pub fn execute_list(command: ListCommand) -> Result<(), Error> {
 
     let reminders = reminder_lint_core::reminders(&conf)?;
 
+    if command.json {
+        println!("{}", serde_json::to_string(&reminders)?);
+        return Ok(());
+    }
+
     for remind in &reminders.expired {
         println!(
             "{}:{} {}",

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -5,8 +5,9 @@ pub mod remind;
 use config::Config;
 use error::ReminderLintError;
 use remind::list_reminders;
+use serde::Serialize;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct Reminders {
     pub expired: Vec<remind::Remind>,
     pub upcoming: Vec<remind::Remind>,

--- a/core/src/remind/mod.rs
+++ b/core/src/remind/mod.rs
@@ -6,6 +6,7 @@ use grep_searcher::sinks::UTF8;
 use grep_searcher::SearcherBuilder;
 use ignore::WalkBuilder;
 use meta::{convert_meta_regex, extract_placeholders};
+use serde::Serialize;
 use std::collections::HashMap;
 use std::io;
 
@@ -13,7 +14,7 @@ use crate::config::Config;
 
 mod meta;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct Remind {
     pub datetime: i64,
     pub message: String,
@@ -21,7 +22,7 @@ pub struct Remind {
     pub meta: HashMap<String, String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct Position {
     pub file: String,
     pub line: u64,


### PR DESCRIPTION
Adds `--json` option to list command.
It makes easier to create editor extensions and some output tools.

## Example

```
$ reminder-lint list --json
{"expired":[{"datetime":1725148800,"message":"<!-- remind: 2024/09/01 todo -->\n","position":{"file":"./CHANGELOG.md","line":5},"meta":{}}],"upcoming":[{"datetime":1733011200,"message":"<!-- remind: 2024/12/01 todo -->\n","position":{"file":"./CHANGELOG.md","line":6},"meta":{}}]}
```