### PR TITLE
action: fixed custom action for multiline output case

### DIFF
--- a/actions/entrypoint.sh
+++ b/actions/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/sh -l
 
 /usr/local/bin/reminder-lint/cli "$@" > /tmp/reminder-lint.log 2>&1
-echo "stdout=$(cat /tmp/reminder-lint.log)" >> $GITHUB_OUTPUT
+
+echo "stdout<<EOF" >> $GITHUB_OUTPUT
+cat /tmp/reminder-lint.log >> $GITHUB_OUTPUT
+echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fixed multiline stdout case.
>Error: Unable to process file command 'output' successfully.