### PR TITLE
readme: specify the tag for custom action document

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run
-        uses: CyberAgent/reminder-lint@main
+        uses: CyberAgent/reminder-lint@0.1.2
         with:
           args: run
 ```
@@ -78,7 +78,7 @@ jobs:
 
       - name: Run
         id: run
-        uses: CyberAgent/reminder-lint@main
+        uses: CyberAgent/reminder-lint@0.1.2
         with:
           args: run
           

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run
-        uses: CyberAgent/reminder-lint@main
+        uses: CyberAgent/reminder-lint@0.1.2
         with:
           args: run
 ```
@@ -79,7 +79,7 @@ jobs:
 
       - name: Run
         id: run
-        uses: CyberAgent/reminder-lint@main
+        uses: CyberAgent/reminder-lint@0.1.2
         with:
           args: run
           


### PR DESCRIPTION
In the future, we may make breaking changes for the development of new versions.
To ensure users can continue to use this tool in their environments, we have explicitly specified the custom action version in the README.
The latest version is [0.1.2](https://github.com/CyberAgent/reminder-lint/tree/0.1.2).