### PR TITLE
Bump up toolchain version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.84
+          toolchain: 1.85
 
       - name: Install cargo-release
         run: cargo install cargo-release --locked


### PR DESCRIPTION
I was attempting a canary release failed due to a cargo-release installation issue. so, I try to fix this by upgrading the toolchain version.


> Run cargo install cargo-release --locked
    Updating crates.io index
error: cannot install package `cargo-release 0.25.18`, it requires rustc 1.85 or newer, while the currently active rustc version is 1.84.1
`cargo-release 0.25.17` supports rustc 1.82
Error: Process completed with exit code [10](https://github.com/CyberAgent/reminder-lint/actions/runs/15939730083/job/44965977164#step:6:11)1.

https://github.com/CyberAgent/reminder-lint/actions/runs/15939730083/job/44965977164