### PR TITLE
Escape title of pull request in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,13 +59,15 @@ jobs:
           OUTPUT: CHANGELOG.md
 
       - name: Cargo release commit
+        env:
+          PR_BODY: ${{ steps.git-cliff.outputs.content }}
         run: |
           git checkout -b release-${{ github.event.inputs.version }}
           git add CHANGELOG.md
           cargo release commit --execute --no-confirm
           git push -u origin HEAD
           git fetch origin main
-          gh pr create --title "Release ${{ github.event.inputs.version }}" --body "${{ steps.git-cliff.outputs.content }}"
+          gh pr create --title "Release ${{ github.event.inputs.version }}" --body "$PR_BODY"
           
           git tag "${{ github.event.inputs.version }}"
           git push origin "${{ github.event.inputs.version }}"


### PR DESCRIPTION
https://github.com/CyberAgent/reminder-lint/actions/runs/15987866853/job/45096294480

> /home/runner/work/_temp/1d46ad68-7292-4006-a9b3-1082a4036359.sh: line 42: syntax error near unexpected token `('

The release workflow failed due to the above error. It appears this failure was caused by an unescaped character being rendered in the PR body.

The problematic character is likely present in titles like https://github.com/CyberAgent/reminder-lint/pull/54.

This PR fixes the issue by escaping the characters by first passing them through an environment variable.