### PR TITLE
Fix invalid syntax in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,14 +36,17 @@ jobs:
           fetch-depth: 0
 
       - name: Install toolchain
+        if: github.ref_name == 'main'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.85
 
       - name: Install cargo-release
+        if: github.ref_name == 'main'
         run: cargo install cargo-release --locked
 
       - name: Cargo release version
+        if: github.ref_name == 'main'
         run: |
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
@@ -51,6 +54,7 @@ jobs:
 
       - id: git-cliff
         name: Generate the changelog
+        if: github.ref_name == 'main'
         uses: orhun/git-cliff-action@v3
         with:
           config: cliff.toml
@@ -58,25 +62,22 @@ jobs:
         env:
           OUTPUT: CHANGELOG.md
 
-      - name: Cargo release commit
+      - name: Cargo release pull request
+        if: github.ref_name == 'main'
+        env:
+          PR_BODY: ${{ steps.git-cliff.outputs.content }}
         run: |
           git checkout -b release-${{ github.event.inputs.version }}
           git add CHANGELOG.md
           cargo release commit --execute --no-confirm
           git push -u origin HEAD
+          gh pr create --title "Release ${{ github.event.inputs.version }}" --body "$PR_BODY" --base "main"
 
       - name: Tag and push version
         run: |
           git fetch origin ${{ github.ref_name }}
           git tag "${{ github.event.inputs.version }}"
           git push origin "${{ github.event.inputs.version }}"
-
-      - name: Create release pull request
-        if: github.ref_name == 'main'
-        env:
-          PR_BODY: ${{ steps.git-cliff.outputs.content }}
-        run: |
-          gh pr create --title "Release ${{ github.event.inputs.version }}" --body "$PR_BODY" --base "main"
 
   build-and-push:
     needs:


### PR DESCRIPTION
This PR corrects and refactors the release.yml workflow.

It fixes an invalid syntax issue caused by steps with duplicate ids. It also prevents the creation of unnecessary release branches when the workflow is triggered on branches other than main. This is achieved by adding if conditions to ensure specific jobs run only on the main branch.

Additionally, the Docker metadata generation has been refactored for conciseness.
