### PR TITLE
Allow dynamic image tags on action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,13 +5,29 @@ inputs:
   args:
     description: Arguments to pass to the reminder-lint.
     default: "run"
+  image_tag:
+    description: "Docker image tag for reminder-lint."
+    default: "latest"
 
 outputs:
   stdout:
     description: "The stdout of reminder-lint command."
+    value: ${{ steps.run-lint.outputs.stdout }}
 
 runs:
-  using: docker
-  image: ./actions/Dockerfile
-  args:
-    - ${{ inputs.args }}
+  using: "composite"
+  steps:
+    - name: Run reminder-lint
+      id: run-lint
+      run: |
+        exit_code=0
+        output=$(docker run --rm -v ${{ github.workspace }}:/work -w /work ghcr.io/cyberagent/reminder-lint:${{ inputs.image_tag }} ${{ inputs.args }} 2>&1) || exit_code=$?
+        
+        echo "${output}"
+        
+        echo "stdout<<EOF" >> $GITHUB_OUTPUT
+        echo "${output}" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+        
+        exit $exit_code
+      shell: bash

--- a/actions/Dockerfile
+++ b/actions/Dockerfile
@@ -1,6 +1,0 @@
-FROM ghcr.io/cyberagent/reminder-lint:latest
-
-COPY entrypoint.sh /usr/local/bin/reminder-lint/
-RUN chmod +x /usr/local/bin/reminder-lint/entrypoint.sh
-
-ENTRYPOINT [ "/usr/local/bin/reminder-lint/entrypoint.sh" ]

--- a/actions/entrypoint.sh
+++ b/actions/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh -l
-
-/usr/local/bin/reminder-lint/cli "$@" > /tmp/reminder-lint.log 2>&1
-
-echo "stdout<<EOF" >> $GITHUB_OUTPUT
-cat /tmp/reminder-lint.log >> $GITHUB_OUTPUT
-echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR updates the GitHub Action to allow specifying the Docker image tag and improves error reporting.

An `image_tag` input (defaults to latest) has been added to allow running specific versions of reminder-lint.

The action now properly captures stderr and the exit code, ensuring that linter failures are clearly reported in the action logs.
This makes the action more flexible and easier to debug.

```yml
- name: Validate
  uses: CyberAgent/reminder-lint@canary
  with:
    args: validate
    image_tag: v0.2.0.canary.1
```