### PR TITLE
Add support for homebrew publisher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,23 +6,6 @@ members = [
 
 resolver = "2"
 
-# Config for 'cargo dist'
-[workspace.metadata.dist]
-# The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.28.0"
-# The installers to generate for each app
-installers = ["shell"]
-# Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
-# CI backends to support
-ci = "github"
-# Publish jobs to run in CI
-pr-run-mode = "skip"
-# Whether to install an updater program
-install-updater = false
-# Skip checking whether the specified configuration files are up to date
-allow-dirty = ["ci"]
-
 # The profile that 'cargo dist' will build with
 [profile.dist]
 inherits = "release"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -1,0 +1,25 @@
+[workspace]
+members = ["cargo:."]
+
+# Config for 'dist'
+[dist]
+# The preferred dist version to use in CI (Cargo.toml SemVer syntax)
+cargo-dist-version = "0.28.0"
+# The installers to generate for each app
+installers = ["shell", "homebrew"]
+# Target platforms to build apps for (Rust target-triple syntax)
+targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+# CI backends to support
+ci = "github"
+# Which actions to run on pull requests
+pr-run-mode = "skip"
+# Whether to install an updater program
+install-updater = false
+# Skip checking whether the specified configuration files are up to date
+allow-dirty = ["ci"]
+# A GitHub repo to push Homebrew formulas to
+tap = "CyberAgent/homebrew-tap"
+# Path that installers should place binaries in
+install-path = "CARGO_HOME"
+# Publish jobs to run in CI
+publish-jobs = ["homebrew"]


### PR DESCRIPTION
Update the configuration file for Homebrew package publication using cargo-dist. 

And the latest version of cargo-dist now seems to use dist-workspace.toml.

https://github.com/axodotdev/cargo-dist/pull/1463