### PR TITLE
Suppress Docker pull output in GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,10 +24,10 @@ runs:
         output=$(docker run -q --rm -v ${{ github.workspace }}:/work -w /work ghcr.io/cyberagent/reminder-lint:${{ inputs.image_tag }} ${{ inputs.args }} 2>&1) || exit_code=$?
 
         echo "${output}"
-        
+
         echo "stdout<<EOF" >> $GITHUB_OUTPUT
         echo "${output}" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
-        
+
         exit $exit_code
       shell: bash


### PR DESCRIPTION
## Problem

After merged https://github.com/CyberAgent/reminder-lint/pull/64, the GitHub Action started displaying Docker pull progress output (e.g., "Unable to find image...", "Pulling from...", "Download complete") which cluttered the action logs and obscured the actual reminder-lint execution results.

## Solution

Added `docker pull -q` command before running the container to pre-pull the image with suppressed output.