### PR TITLE
Add continue-on-error to workflow examples for notify step execution

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -78,6 +78,7 @@ jobs:
 
       - name: Run
         id: run
+        continue-on-error: true
         uses: CyberAgent/reminder-lint@0.1.2
         with:
           args: run

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ jobs:
 
       - name: Run
         id: run
+        continue-on-error: true
         uses: CyberAgent/reminder-lint@0.1.2
         with:
           args: run


### PR DESCRIPTION
This PR updates the workflow examples in README files to ensure the notify step executes even when reminder-lint exits with a non-zero status code.

The recent change in `action.yml` (commit 6a24ef5) properly propagates exit codes from the reminder-lint command. While this is the correct behavior, it causes the notify step in the documented workflow examples to be skipped when reminder-lint finds reminders (exit code 1).

Previously, the action always returned exit code 0 due to the shell script implementation, which meant subsequent steps would always run. The new implementation correctly returns the actual exit code from reminder-lint.

```yaml
- name: Run
  id: run
  continue-on-error: true  # Ensures notify step runs even on exit 1
  uses: CyberAgent/reminder-lint@0.1.2
  with:
    args: run
```
