### PR TITLE
Update git-cliff-action to v4 to resolve Debian Buster repository errors

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -47,7 +47,7 @@ jobs:
 
       - id: git-cliff
         name: Generate the changelog
-        uses: orhun/git-cliff-action@b946ed27a675d653b308f29a7bbad813b85bf7aa # v3.3.0
+        uses: orhun/git-cliff-action@98c93442bb05a455a77bee982867857ae748eeea # v4.5.1
         with:
           config: cliff.toml
           args: --verbose --tag "${{ github.event.inputs.version }}"


### PR DESCRIPTION
The workflow is failing with the following error when using git-cliff-action@b946ed27a675d653b308f29a7bbad813b85bf7aa (v3.3.0):
- `E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.`
- HTTP 404 errors when attempting to access Debian Buster repositories

https://github.com/CyberAgent/reminder-lint/actions/runs/17850905100

## Root Cause
git-cliff-action v3.3.0 uses an outdated Docker image that attempts to access Debian Buster repositories, which have been archived and are no longer available at the standard URLs.

## Solution
Updated git-cliff-action from v3.3.0 to v4, which uses a newer Docker image with current Debian repositories.