### PR TITLE
Add Homebrew installation method to README

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -28,6 +28,11 @@ $ reminder-lint run
 
 ## インストール
 
+### Homebrew
+```shell
+$ brew install CyberAgent/tap/reminder-lint
+```
+
 ### Docker
 ```shell
 $ docker run --rm -v "$(pwd):/workspace" --workdir /workspace ghcr.io/cyberagent/reminder-lint:latest run

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ $ reminder-lint run
 
 ## Install
 
+### Homebrew
+```shell
+$ brew install CyberAgent/tap/reminder-lint
+```
+
 ### Docker
 ```shell
 $ docker run --rm -v "$(pwd):/workspace" --workdir /workspace ghcr.io/cyberagent/reminder-lint:latest run


### PR DESCRIPTION
This PR adds Homebrew installation instructions to the README, making it easier for macOS and Linux users to install `reminder-lint` through the Homebrew package manager.

https://docs.brew.sh/Taps